### PR TITLE
Use pytest instead of py.test per upstream recommendation, #dropthedot

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -6,7 +6,7 @@ python=
   3.6: py36, flake8
 
 [testenv]
-commands=py.test --cov rmdups {posargs}
+commands=pytest --cov rmdups {posargs}
 deps=
     pytest
     pytest-cov


### PR DESCRIPTION
http://blog.pytest.org/2016/whats-new-in-pytest-30/
https://twitter.com/hashtag/dropthedot